### PR TITLE
Add npm install in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In this example we'll use five strategies:
 1. Fetch dependecies:
 
 	```shell
-	$ mix deps.get
+	$ mix deps.get && npm install
 	```
 
 1. Run server:


### PR DESCRIPTION
to avoid following error from showing up

```
[error] Could not start node watcher because script "node_modules/brunch/bin/brunch" does not exist. Your Phoenix application is still running, however assets won't be compiled. You may fix this by running "npm install".
```