### PR TITLE
got an avatar for github

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,7 @@ config :phoenix, :generators,
 config :ueberauth, Ueberauth,
   providers: [
     facebook: { Ueberauth.Strategy.Facebook, [] },
-    github: { Ueberauth.Strategy.Github, [] },
+    github: { Ueberauth.Strategy.Github, [default_scope: "user:email"] },
     google: { Ueberauth.Strategy.Google, [] },
     identity: { Ueberauth.Strategy.Identity, [
         callback_methods: ["POST"],

--- a/web/models/user_from_auth.ex
+++ b/web/models/user_from_auth.ex
@@ -2,6 +2,8 @@ defmodule UserFromAuth do
   @moduledoc """
   Retrieve the user information from an auth request
   """
+  require Logger
+  require Poison
 
   alias Ueberauth.Auth
 
@@ -17,8 +19,21 @@ defmodule UserFromAuth do
     {:ok, basic_info(auth)}
   end
 
+  # github does it this way
+  defp avatar_from_auth( %{info: %{urls: %{avatar_url: image}} }), do: image
+
+  #facebook does it this way
+  defp avatar_from_auth( %{info: %{image: image} }), do: image
+
+  # default case if nothing matches
+  defp avatar_from_auth( auth ) do
+    Logger.warn auth.provider <> " needs to find an avatar URL!"
+    Logger.debug(Poison.encode!(auth))
+    nil
+  end
+
   defp basic_info(auth) do
-    %{id: auth.uid, name: name_from_auth(auth), avatar: auth.info.image}
+    %{id: auth.uid, name: name_from_auth(auth), avatar: avatar_from_auth(auth)}
   end
 
   defp name_from_auth(auth) do


### PR DESCRIPTION
Github has a null in the auth structure for info.image, but puts the avatar url in info.urls.avatar_url instead. 