### PR TITLE
Change logout method to post

### DIFF
--- a/lib/ueberauth_example_web/router.ex
+++ b/lib/ueberauth_example_web/router.ex
@@ -22,7 +22,7 @@ defmodule UeberauthExampleWeb.Router do
     get "/:provider", AuthController, :request
     get "/:provider/callback", AuthController, :callback
     post "/:provider/callback", AuthController, :callback
-    delete "/logout", AuthController, :delete
+    post "/logout", AuthController, :delete
   end
 
   scope "/", UeberauthExampleWeb do

--- a/lib/ueberauth_example_web/templates/page/index.html.eex
+++ b/lib/ueberauth_example_web/templates/page/index.html.eex
@@ -9,7 +9,7 @@
   <%= if @current_user do %>
     <h2>Welcome, <%= @current_user.name %>!</h2>
     <img src="<%= @current_user.avatar %>" class="img-circle"/>
-    <%= button "Logout", to: auth_path(@conn, :delete), method: :delete, class: "btn btn-danger" %>
+    <%= button "Logout", to: auth_path(@conn, :delete), method: :post, class: "btn btn-danger" %>
     <br>
   <% else %>
     <a class="btn btn-primary btn-lg" href="/auth/github">


### PR DESCRIPTION
The logout link does not work in this example because [Phoenix HTML changes the method from `delete` to `post`](https://github.com/phoenixframework/phoenix_html/blob/master/priv/static/phoenix_html.js#L34). I would have submitted a fix to Phoenix HTML but apparently [the HTML spec only supports `get` and `post`](http://w3c.github.io/html/sec-forms.html#element-attrdef-form-method). This PR switches the logout link to use `post` instead of `delete`.

Fixes #12.