### PR TITLE
Renew session on successful login

### DIFF
--- a/lib/ueberauth_example_web/controllers/auth_controller.ex
+++ b/lib/ueberauth_example_web/controllers/auth_controller.ex
@@ -31,6 +31,7 @@ defmodule UeberauthExampleWeb.AuthController do
         conn
         |> put_flash(:info, "Successfully authenticated.")
         |> put_session(:current_user, user)
+        |> configure_session(renew: true)
         |> redirect(to: "/")
       {:error, reason} ->
         conn


### PR DESCRIPTION
Adding this line as it appears to be a recommended best practise:

> “The last step is extremely important and it protects us from session fixation attacks. It tells Plug to send the session cookie back to the client with a different identifier, in case an attacker knew, by any chance, the previous one.”

Excerpt From: Chris McCord, Bruce Tate, José Valim. [“Programming Phoenix ≥ 1.4”](https://pragprog.com/book/phoenix14/programming-phoenix-1-4) Chapter 5.