### PR TITLE
Fix logger warning in default avatar_from_auth

### DIFF
--- a/lib/ueberauth_example_web/models/user_from_auth.ex
+++ b/lib/ueberauth_example_web/models/user_from_auth.ex
@@ -27,7 +27,7 @@ defmodule UserFromAuth do
 
   # default case if nothing matches
   defp avatar_from_auth( auth ) do
-    Logger.warn auth.provider <> " needs to find an avatar URL!"
+    Logger.warn "#{auth.provider} needs to find an avatar URL!"
     Logger.debug(Poison.encode!(auth))
     nil
   end


### PR DESCRIPTION
Trying to concatenate an atom with a string/binary throws an `ArgumentError`. Therefore I simply changed to string interpolation to make implicit use of `to_string`.