### PR TITLE
Update npm install instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In this example we'll use five strategies:
 1. Fetch dependecies:
 
 	```shell
-	$ mix deps.get && npm install
+	$ mix deps.get && npm install --prefix assets
 	```
 
 1. Run server:


### PR DESCRIPTION
This PR updates the command `mix deps.get && npm install` fails, as the package.json file is on the assets directory, the new command `mix deps.get && npm install --prefix assets` will work.