### PR TITLE
Update URL to `git clone` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this example we'll use five strategies:
 1. Clone the project:
 
 	```shell
-	$ git clone git@github.com:ueberauth/ueberauth_example.git
+	$ git clone https://github.com/ueberauth/ueberauth_example.git
 	$ cd ueberauth_example
 	```
 


### PR DESCRIPTION
Old URL didn't work for me.  This one does.  

Closes issue #81.