### PR TITLE
[docs] Update Erlang and Elixir prerequisite versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ In this example we'll use five strategies:
 
 1. Ensure the following prerequisites are met/installed:
 
-  + Erlang 19
-  + Elixir 1.3
+  + Erlang 23
+  + Elixir 1.11
 
 1. Retrieve app ids and secrets and set environment variables:
 


### PR DESCRIPTION
Update Erlang and Elixir prerequisite versions to reflect the versions declared in [`.tool-versions`](https://github.com/ueberauth/ueberauth_example/blob/09e2b3e/.tool-versions).